### PR TITLE
HOPSWORKS-555

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,5 @@ cookbook 'magic_shell'
 
 cookbook 'apache2', '~> 3.3.0'
 metadata
+
+cookbook 'ulimit', github: "hopshadoop/chef-ulimit", branch: "master"

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,8 +11,9 @@ supports 'ubuntu', '= 16.04'
 
 supports 'centos', '= 7.2'
 
-depends 'magic_shell'
-depends 'apache2'
+depends           'magic_shell'
+depends           'apache2'
+depends           'ulimit'
 
 recipe "conda::install", "Installs  conda"
 recipe "conda::default", "Configures conda"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -81,3 +81,17 @@ end
 magic_shell_environment 'PATH' do
   value "$PATH:#{node['conda']['base_dir']}/bin"
 end
+
+
+ulimit_domain node['conda']['user'] do
+  rule do
+    item :nice
+    type :hard
+    value -10
+  end
+  rule do
+    item :nice
+    type :soft
+    value -10
+  end
+end


### PR DESCRIPTION
Increase process priority of anaconda commands
reducing nice level for the anconda user (used to execute the conda commands issued by kagent).
https://hopshadoop.atlassian.net/browse/HOPSWORKS-555